### PR TITLE
prevent crash on dismount

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -242,7 +242,7 @@ function lib_mount.attach(entity, player, attach_at, eye_offset)
 end
 
 function lib_mount.detach(entity, player, offset)
-	entity.driver = nil
+	if entity ~= nil then entity.driver = nil end
 	player:set_detach()
 	default.player_attached[player:get_player_name()] = false
 	default.player_set_animation(player, "stand" , 30)


### PR DESCRIPTION
I have a number of mobs on my server, including mobs_horse (blert2112, mobs_more_animals)

For some reason on dismount, the server crashes, pointing at line 245 accessing entity, a nil value

This shuold fix the issue generally, but I should also wonder why not create a dependency on lib_mount externally?
