### PR TITLE
Baddies use API to despawn; also keep pig

### DIFF
--- a/baddies.lua
+++ b/baddies.lua
@@ -1,11 +1,9 @@
--- Fox
-if dmobs.destructive then
-mobs:register_mob("dmobs:pig_evil", {
+local pigdef = {
 	type = "monster",
 	passive = true,
 	reach = 3,
 	damage = 2,
-	attack_type = "explode",
+	attack_type = "dogfight",
 	explosion_radius = 2,
 	hp_min = 12,
 	hp_max = 22,
@@ -31,9 +29,8 @@ mobs:register_mob("dmobs:pig_evil", {
 	drops = {
 		{name = "mobs:meat_raw", chance = 2, min = 1, max = 1},
 	},
-	sounds = {
-      random = "mobs_pig",
-	  explode = "tnt_explode",
+	pigdef.sounds = {
+		random = "mobs_pig",
 	},
 	do_custom = function(self)
 		if self.state == "attack" then
@@ -65,12 +62,18 @@ mobs:register_mob("dmobs:pig_evil", {
 
 		mobs:capture_mob(self, clicker, 0, 5, 50, false, nil)
 	end,
-})
+}
+
+if dmobs.destructive then
+	pigdef.sounds.explode = "mobs_pig"
+	pigdef.attack_type = "explode",
+end
+
+mobs:register_mob("dmobs:pig_evil", pigdef)
 
 mobs:register_spawn("dmobs:pig_evil", {"default:pine_needles","default:leaves"}, 20, 10, 15000, 2, 31000)
 
 mobs:register_egg("dmobs:pig_evil", "kamikaze Pig", "wool_pink.png", 1)
-end
 
 -- Fox
 mobs:register_mob("dmobs:fox", {

--- a/baddies.lua
+++ b/baddies.lua
@@ -65,7 +65,7 @@ local pigdef = {
 }
 
 if dmobs.destructive then
-	pigdef.sounds.explode = "mobs_pig"
+	pigdef.sounds.explode = "tnt_explode"
 	pigdef.attack_type = "explode"
 end
 

--- a/baddies.lua
+++ b/baddies.lua
@@ -14,10 +14,10 @@ local pigdef = {
 	textures = {
 		{"dmobs_flying_pig_mean.png"},
 	},
-   jump = true,
-   fly = true,
-   fall_speed = 0,
-   stepheight = 1.5,
+	jump = true,
+	fly = true,
+	fall_speed = 0,
+	stepheight = 1.5,
 	blood_texture = "mobs_blood.png",
 	visual_size = {x=1, y=1},
 	makes_footstep_sound = true,
@@ -29,7 +29,7 @@ local pigdef = {
 	drops = {
 		{name = "mobs:meat_raw", chance = 2, min = 1, max = 1},
 	},
-	pigdef.sounds = {
+	sounds = {
 		random = "mobs_pig",
 	},
 	do_custom = function(self)
@@ -66,7 +66,7 @@ local pigdef = {
 
 if dmobs.destructive then
 	pigdef.sounds.explode = "mobs_pig"
-	pigdef.attack_type = "explode",
+	pigdef.attack_type = "explode"
 end
 
 mobs:register_mob("dmobs:pig_evil", pigdef)

--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,7 @@ dmobs.dragons = true
 -- Enable fireballs/explosions
 dmobs.destructive = true
 
---peaceful mobs setting
+-- load baddies
 
 dofile(minetest.get_modpath("dmobs").."/baddies.lua")
 

--- a/init.lua
+++ b/init.lua
@@ -14,9 +14,7 @@ dmobs.destructive = true
 
 --peaceful mobs setting
 
-if not minetest.setting_getbool("only_peaceful_mobs") then
-	dofile(minetest.get_modpath("dmobs").."/baddies.lua")
-end
+dofile(minetest.get_modpath("dmobs").."/baddies.lua")
 
 --friendly mobs
 


### PR DESCRIPTION
### Change in init.lua

The Mobs api takes care of removing the monsters, don't do it here (otherwise activating `only_peaceful_mobs` after they have been loaded causes unknown entities all over the place).
- See https://github.com/tenplus1/mobs_redo/blob/master/api.lua#L37
- and https://github.com/tenplus1/mobs_redo/blob/master/api.lua#L2034
### Change in baddies.lua

Always have an evil pig - but only make it explode if dmobs.destructive is true, otherwise, make it just punch player
