### PR TITLE
Dragonplus

### DIFF
--- a/dragons/dragon_normal.lua
+++ b/dragons/dragon_normal.lua
@@ -1,5 +1,7 @@
 --dragon
 
+dofile(minetest.get_modpath("dmobs").."/dragons/piloting.lua")
+
 mobs:register_mob("dmobs:dragon", {
    type = "monster",
    passive = false,
@@ -63,6 +65,8 @@ mobs:register_mob("dmobs:dragon", {
 	  punch_end = 47,
    },
 	knock_back = 2,
+	do_custom = dmobs.dragon.step_custom,
+	on_rightclick = dmobs.dragon.on_rc
 })
 
 

--- a/dragons/main.lua
+++ b/dragons/main.lua
@@ -2,65 +2,9 @@
 
 dmobs.dragon = {}
 
-dmobs.dragon.step_custom = function(self, dtime)
-	if self.driver then
-		lib_mount.drive(self, dtime, "walk", "stand", true)
-		if self.state == "attack" then
-			self.state = nil
-		end
-		return false
-	end
-	return true
-end
+dofile(minetest.get_modpath("dmobs").."/dragons/piloting.lua")
 
 local tamed_dragons = {}
-
-dmobs.dragon.ride = function(self, clicker)
-	if self.tamed and self.owner == clicker:get_player_name() then
-		local inv = clicker:get_inventory()
-		
-		if self.driver and clicker == self.driver then
-			object_detach(self, clicker, {x=1, y=0, z=1})
-			
-			if inv:room_for_item("main", "mobs:saddle") then
-					inv:add_item("main", "mobs:saddle")
-			else
-					minetest.add_item(clicker.getpos(), "mobs:saddle")
-			end
-			
-		elseif not self.driver then
-			if clicker:get_wielded_item():get_name() == "mobs:saddle" then
-				object_attach(self, clicker, {x=0, y=12, z=4}, {x=0, y=0, z=4})
-				inv:remove_item("main", "mobs:saddle")
-			end
-		end
-	end
-end
-
-
-dmobs.dragon.on_rc = function(self, clicker)
-	if not clicker or not clicker:is_player() then
-		return
-	end
-	if mobs:feed_tame(self, clicker, 1, false, false) then
-		return
-	end
-	dmobs.dragon.ride(self, clicker)
-end
-
-dmobs.dragon.do_custom = function(self, dtime)
-	if self.driver then
-		object_fly(self, dtime, 10, true, "dmobs:fire_plyr", "walk", "stand")
-		
-		if self.state == "attack" then
-			self.state = "idle"
-		end
-		
-		return false
-	end
-	return true
-end
-
 
 --items and tools
 

--- a/dragons/piloting.lua
+++ b/dragons/piloting.lua
@@ -1,0 +1,61 @@
+
+if not dmobs.dragon then
+	dmobs.dragon = {}
+end
+
+dmobs.dragon.step_custom = function(self, dtime)
+	if self.driver then
+		object_fly(self, dtime, 10, true, "dmobs:fire_plyr", "walk", "stand")
+		if self.state == "attack" then
+			self.state = nil
+		end
+		return false
+	end
+	return true
+end
+
+dmobs.dragon.ride = function(self, clicker)
+	if self.tamed and self.owner == clicker:get_player_name() then
+		local inv = clicker:get_inventory()
+		
+		if self.driver and clicker == self.driver then
+			object_detach(self, clicker, {x=1, y=0, z=1})
+			
+			if inv:room_for_item("main", "mobs:saddle") then
+					inv:add_item("main", "mobs:saddle")
+			else
+					minetest.add_item(clicker.getpos(), "mobs:saddle")
+			end
+			
+		elseif not self.driver then
+			if clicker:get_wielded_item():get_name() == "mobs:saddle" then
+				object_attach(self, clicker, {x=0, y=12, z=4}, {x=0, y=0, z=4})
+				inv:remove_item("main", "mobs:saddle")
+			end
+		end
+	end
+end
+
+
+dmobs.dragon.on_rc = function(self, clicker)
+	if not clicker or not clicker:is_player() then
+		return
+	end
+	if mobs:feed_tame(self, clicker, 1, false, false) then
+		return
+	end
+	dmobs.dragon.ride(self, clicker)
+end
+
+dmobs.dragon.do_custom = function(self, dtime)
+	if self.driver then
+		object_fly(self, dtime, 10, true, "dmobs:fire_plyr", "walk", "stand")
+		
+		if self.state == "attack" then
+			self.state = "idle"
+		end
+		
+		return false
+	end
+	return true
+end

--- a/init.lua
+++ b/init.lua
@@ -8,9 +8,10 @@ dofile(minetest.get_modpath("dmobs").."/api.lua")
 
 -- Enable dragons (disable to remove tamed dragons and dragon bosses)
 dmobs.dragons = minetest.setting_getbool("dmobs.dragons") or false
+dmobs.regulars = minetest.setting_getbool("dmobs.regulars") or false
 
 -- Enable fireballs/explosions
-dmobs.destructive = minetest.setting_getbool("dmobs.destructive") or false
+dmobs.destructive = minetest.setting_getbool("dmobs.destructive") or true
 
 -- Timer for the egg mechanics
 dmobs.eggtimer = tonumber(minetest.setting_get("dmobs.eggtimer") ) or 100
@@ -68,8 +69,10 @@ local mobslist = {
 	"ogre",
 }
 
-for _,mobname in pairs(mobslist) do
-	loadmob(mobname)
+if dmobs.regulars then
+	for _,mobname in pairs(mobslist) do
+		loadmob(mobname)
+	end
 end
 
 -- dragons!!
@@ -87,9 +90,9 @@ else
 	loadmob("wyvern","/dragons/")
 	
 	dofile(minetest.get_modpath("dmobs").."/dragons/eggs.lua")
-	dofile(minetest.get_modpath("dmobs").."/arrows/dragonfire.lua")
-	dofile(minetest.get_modpath("dmobs").."/arrows/dragonarrows.lua")
 end
+dofile(minetest.get_modpath("dmobs").."/arrows/dragonfire.lua")
+dofile(minetest.get_modpath("dmobs").."/arrows/dragonarrows.lua")
 
 -- General arrow definitions
 

--- a/init.lua
+++ b/init.lua
@@ -8,10 +8,10 @@ dofile(minetest.get_modpath("dmobs").."/api.lua")
 
 -- Enable dragons (disable to remove tamed dragons and dragon bosses)
 dmobs.dragons = minetest.setting_getbool("dmobs.dragons") or false
-dmobs.regulars = minetest.setting_getbool("dmobs.regulars") or false
+dmobs.regulars = minetest.setting_getbool("dmobs.regulars") or true
 
 -- Enable fireballs/explosions
-dmobs.destructive = minetest.setting_getbool("dmobs.destructive") or true
+dmobs.destructive = minetest.setting_getbool("dmobs.destructive") or false
 
 -- Timer for the egg mechanics
 dmobs.eggtimer = tonumber(minetest.setting_get("dmobs.eggtimer") ) or 100

--- a/spawn.lua
+++ b/spawn.lua
@@ -1,49 +1,53 @@
--- friendlies
+if dmobs.regulars then
+	-- friendlies
 
-mobs:register_spawn("dmobs:nyan", {"default:pine_needles","default:leaves"}, 20, 10, 50000, 2, 31000)
-mobs:register_spawn("dmobs:nyan", {"nyanland:meseleaves"}, 20, 10, 15000, 2, 31000)
+	mobs:register_spawn("dmobs:nyan", {"default:pine_needles","default:leaves"}, 20, 10, 50000, 2, 31000)
+	mobs:register_spawn("dmobs:nyan", {"nyanland:meseleaves"}, 20, 10, 15000, 2, 31000)
 
-mobs:register_spawn("dmobs:hedgehog", {"default:dirt_with_grass","default:pine_needles"}, 20, 10, 15000, 2, 31000)
-mobs:register_spawn("dmobs:whale", {"default:water_source"}, 20, 10, 15000, -20, 1000)
-mobs:register_spawn("dmobs:owl", {"default:leaves","default:tree"}, 20, 10, 15000, 2, 31000)
-mobs:register_spawn("dmobs:gnorm", {"default:dirt_with_grass","default:wood"}, 20, 10, 32000, 2, 31000)
-mobs:register_spawn("dmobs:tortoise", {"default:clay","default:sand"}, 20, 10, 15000, 2, 31000)
-mobs:register_spawn("dmobs:elephant", {"default:dirt_with_dry_grass","default:desert_sand"}, 20, 10, 15000, 2, 31000)
-mobs:register_spawn("dmobs:badger", {"default:dirt_with_grass","default:dirt"}, 20, 10, 15000, 2, 31000)
-mobs:register_spawn("dmobs:pig", {"default:pine_needles","default:leaves", "nyanland:cloudstone"}, 20, 10, 32000, 2, 31000)
-mobs:register_spawn("dmobs:panda", {"default:dirt_with_grass","ethereal:bamboo_dirt"}, 20, 10, 15000, 2, 31000)
+	mobs:register_spawn("dmobs:hedgehog", {"default:dirt_with_grass","default:pine_needles"}, 20, 10, 15000, 2, 31000)
+	mobs:register_spawn("dmobs:whale", {"default:water_source"}, 20, 10, 15000, -20, 1000)
+	mobs:register_spawn("dmobs:owl", {"default:leaves","default:tree"}, 20, 10, 15000, 2, 31000)
+	mobs:register_spawn("dmobs:gnorm", {"default:dirt_with_grass","default:wood"}, 20, 10, 32000, 2, 31000)
+	mobs:register_spawn("dmobs:tortoise", {"default:clay","default:sand"}, 20, 10, 15000, 2, 31000)
+	mobs:register_spawn("dmobs:elephant", {"default:dirt_with_dry_grass","default:desert_sand"}, 20, 10, 15000, 2, 31000)
+	mobs:register_spawn("dmobs:badger", {"default:dirt_with_grass","default:dirt"}, 20, 10, 15000, 2, 31000)
+	mobs:register_spawn("dmobs:pig", {"default:pine_needles","default:leaves", "nyanland:cloudstone"}, 20, 10, 32000, 2, 31000)
+	mobs:register_spawn("dmobs:panda", {"default:dirt_with_grass","ethereal:bamboo_dirt"}, 20, 10, 15000, 2, 31000)
 
--- baddies
+	-- baddies
 
-mobs:register_spawn("dmobs:wasp", {"default:dirt_with_grass"}, 20, 10, 32000, 2, 31000)
-mobs:register_spawn("dmobs:wasp", {"dmobs:hive"}, 20, 10, 16000, 2, 31000)
-mobs:register_spawn("dmobs:wasp_leader", {"default:dirt_with_grass","dmobs:hive"}, 20, 10, 64000, 2, 31000)
+	mobs:register_spawn("dmobs:wasp", {"default:dirt_with_grass"}, 20, 10, 32000, 2, 31000)
+	mobs:register_spawn("dmobs:wasp", {"dmobs:hive"}, 20, 10, 16000, 2, 31000)
+	mobs:register_spawn("dmobs:wasp_leader", {"default:dirt_with_grass","dmobs:hive"}, 20, 10, 64000, 2, 31000)
 
-mobs:register_spawn("dmobs:golem", {"default:stone"}, 7, 0, 16000, 2, 31000)
-mobs:register_spawn("dmobs:pig_evil", {"default:pine_needles","default:leaves"}, 20, 10, 32000, 2, 31000)
-mobs:register_spawn("dmobs:fox", {"default:dirt_with_grass","default:dirt"}, 20, 10, 32000, 2, 31000)
+	mobs:register_spawn("dmobs:golem", {"default:stone"}, 7, 0, 16000, 2, 31000)
+	mobs:register_spawn("dmobs:pig_evil", {"default:pine_needles","default:leaves"}, 20, 10, 32000, 2, 31000)
+	mobs:register_spawn("dmobs:fox", {"default:dirt_with_grass","default:dirt"}, 20, 10, 32000, 2, 31000)
 
-if not dmobs.dragons then
-	mobs:register_spawn("dmobs:orc", {"default:snow","default:snow_block", "default:desert_sand"}, 20, 10, 15000, 2, 31000)
-	mobs:register_spawn("dmobs:ogre", {"default:snow","default:dirt_with_dry_grass", "default:desert_sand"}, 20, 10, 15000, 2, 31000)
-else
-	mobs:register_spawn("dmobs:orc", {"default:snow","default:snow_block", "default:desert_sand"}, 20, 10, 3500, 2, 31000)
-	mobs:register_spawn("dmobs:ogre", {"default:snow","default:dirt_with_dry_grass", "default:desert_sand"}, 20, 10, 350, 2, 31000)
+	if not dmobs.dragons then
+		mobs:register_spawn("dmobs:orc", {"default:snow","default:snow_block", "default:desert_sand"}, 20, 10, 15000, 2, 31000)
+		mobs:register_spawn("dmobs:ogre", {"default:snow","default:dirt_with_dry_grass", "default:desert_sand"}, 20, 10, 15000, 2, 31000)
+	else
+		mobs:register_spawn("dmobs:orc", {"default:snow","default:snow_block", "default:desert_sand"}, 20, 10, 3500, 2, 31000)
+		mobs:register_spawn("dmobs:ogre", {"default:snow","default:dirt_with_dry_grass", "default:desert_sand"}, 20, 10, 350, 2, 31000)
+	end
+
+
+	mobs:register_spawn("dmobs:rat", {"default:stone","default:sand"}, 20, 0, 32000, 2, 31000)
+	mobs:register_spawn("dmobs:treeman", {"default:leaves", "default:pine_needles"}, 7, 0, 16000, 2, 31000)
+	mobs:register_spawn("dmobs:skeleton", {"default:stone"}, 7, 0, 16000, 2, 31000)
 end
-
-
-mobs:register_spawn("dmobs:rat", {"default:stone","default:sand"}, 20, 0, 32000, 2, 31000)
-mobs:register_spawn("dmobs:treeman", {"default:leaves", "default:pine_needles"}, 7, 0, 16000, 2, 31000)
-mobs:register_spawn("dmobs:skeleton", {"default:stone"}, 7, 0, 16000, 2, 31000)
 
 -- dragons
 
-mobs:register_spawn("dmobs:dragon", {"default:leaves","default:dirt_with_grass"}, 20, 10, 64000, 2, 31000)
+if not dmobs.dragons then
+	mobs:register_spawn("dmobs:dragon", {"default:leaves","default:dirt_with_grass"}, 20, 10, 64000, 2, 31000)
 
-mobs:register_spawn("dmobs:dragon2", {"default:pine_needles"}, 20, 10, 64000, 2, 31000)
-mobs:register_spawn("dmobs:dragon3", {"default:acacia_leaves","default:dirt_with_dry_grass"}, 20, 10, 64000, 2, 31000)
-mobs:register_spawn("dmobs:dragon4", {"default:jungleleaves"}, 20, 10, 64000, 2, 31000)
-mobs:register_spawn("dmobs:waterdragon", {"default:water_source"}, 20, 10, 32000, 1, 31000, false)
-mobs:register_spawn("dmobs:wyvern",	{"default:leaves"}, 20, 10, 32000, 1, 31000, false)
-mobs:register_spawn("dmobs:dragon_great", {"default:lava_source"}, 20, 0, 64000, -21000, 1000, false)
-
+else
+	mobs:register_spawn("dmobs:dragon2", {"default:pine_needles"}, 20, 10, 64000, 2, 31000)
+	mobs:register_spawn("dmobs:dragon3", {"default:acacia_leaves","default:dirt_with_dry_grass"}, 20, 10, 64000, 2, 31000)
+	mobs:register_spawn("dmobs:dragon4", {"default:jungleleaves"}, 20, 10, 64000, 2, 31000)
+	mobs:register_spawn("dmobs:waterdragon", {"default:water_source"}, 20, 10, 32000, 1, 31000, false)
+	mobs:register_spawn("dmobs:wyvern",	{"default:leaves"}, 20, 10, 32000, 1, 31000, false)
+	mobs:register_spawn("dmobs:dragon_great", {"default:lava_source"}, 20, 0, 64000, -21000, 1000, false)
+end


### PR DESCRIPTION
* Make normal dragon pilotable
* Allow disabling the "regular" mobs to allow focusing on the dragons (they are still active by default)
* Change piloting from `lib_mount.drive` to `object_fly`